### PR TITLE
fix: issue with phone number lib being imported when not used

### DIFF
--- a/tests/test_views_profile.py
+++ b/tests/test_views_profile.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .utils import UserMixin
+
+
+class ProfileTest(UserMixin, TestCase):
+    PHONENUMBER_PLUGIN_NAME = 'two_factor.plugins.phonenumber'
+    EXPECTED_BASE_CONTEXT_KEYS = {
+        'default_device',
+        'default_device_type',
+        'backup_tokens',
+    }
+    EXPECTED_PHONENUMBER_PLUGIN_ADDITIONAL_KEYS = {
+        'backup_phones',
+        'available_phone_methods',
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.enable_otp()
+        self.login_user()
+
+    @classmethod
+    def get_installed_apps_list(cls, with_phone_number_plugin=True):
+        apps = set(settings.INSTALLED_APPS)
+        if with_phone_number_plugin:
+            apps.add(cls.PHONENUMBER_PLUGIN_NAME)
+        else:
+            apps.remove(cls.PHONENUMBER_PLUGIN_NAME)
+        return list(apps)
+
+    def get_profile(self):
+        url = reverse('two_factor:profile')
+        return self.client.get(url)
+
+    def test_get_profile_without_phonenumer_plugin_enabled(self):
+        apps_list = self.get_installed_apps_list(with_phone_number_plugin=False)
+        with override_settings(INSTALLED_APPS=apps_list):
+            response = self.get_profile()
+            context_keys = set(response.context.keys())
+            self.assertTrue(self.EXPECTED_BASE_CONTEXT_KEYS.issubset(context_keys))
+            # None of the phonenumber related keys are present
+            self.assertTrue(
+                self.EXPECTED_PHONENUMBER_PLUGIN_ADDITIONAL_KEYS.isdisjoint(
+                    context_keys
+                )
+            )
+
+    def test_get_profile_with_phonenumer_plugin_enabled(self):
+        apps_list = self.get_installed_apps_list(with_phone_number_plugin=True)
+        with override_settings(INSTALLED_APPS=apps_list):
+            response = self.get_profile()
+            context_keys = set(response.context.keys())
+            expected_keys = (
+                self.EXPECTED_BASE_CONTEXT_KEYS
+                | self.EXPECTED_PHONENUMBER_PLUGIN_ADDITIONAL_KEYS
+            )
+            self.assertTrue(expected_keys.issubset(context_keys))

--- a/two_factor/views/profile.py
+++ b/two_factor/views/profile.py
@@ -1,3 +1,4 @@
+from django.apps.registry import apps
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, resolve_url
@@ -31,16 +32,23 @@ class ProfileView(TemplateView):
     def get_context_data(self, **kwargs):
         try:
             backup_tokens = self.request.user.staticdevice_set.all()[0].token_set.count()
+
         except Exception:
             backup_tokens = 0
 
-        return {
+        context = {
             'default_device': default_device(self.request.user),
             'default_device_type': default_device(self.request.user).__class__.__name__,
-            'backup_phones': backup_phones(self.request.user),
             'backup_tokens': backup_tokens,
-            'available_phone_methods': get_available_phone_methods()
         }
+
+        if (apps.is_installed("phonenumber")):
+            context.update({
+                'backup_phones': backup_phones(self.request.user),
+                'phone_methods': get_available_phone_methods(),
+            })
+
+        return context
 
 
 @class_view_decorator(never_cache)

--- a/two_factor/views/profile.py
+++ b/two_factor/views/profile.py
@@ -42,10 +42,10 @@ class ProfileView(TemplateView):
             'backup_tokens': backup_tokens,
         }
 
-        if (apps.is_installed("phonenumber")):
+        if (apps.is_installed('two_factor.plugins.phonenumber')):
             context.update({
                 'backup_phones': backup_phones(self.request.user),
-                'phone_methods': get_available_phone_methods(),
+                'available_phone_methods': get_available_phone_methods(),
             })
 
         return context


### PR DESCRIPTION
## Description
Crash was being caused by assuming `phonenumbers` was being used, even when not enabled. This PR checks to see if the library is included, for backwards compatibility, before including it.

## Motivation and Context
When you view the 2FA "profile" page, it calls `backup_phones()` directly from the phone plugin, which causes a `from .models import PhoneDevice`

This then means that the `PhoneDevice` model is known to django's model registry and it gets associated with the `two_factor` rather than `two_factor.plugins.phonenumber`.

It does not cause a problem right after because the `PhoneDevice` sits on the end of the list of available models for checking to see if a user has 2FA.

Later on though in [device_classes](https://github.com/django-otp/django-otp/blob/master/src/django_otp/__init__.py#L160), when you look at a user with **no 2FA methods** it crashes because it tries to look up data on that non-existent table.

In short: After the first call to `backup_phones()`, the django process then erroneously has PhoneDevice in it's model registry. After that, `django_otp.device_classes` picks up `PhoneDevice` as one of the available options and any time `devices_for_user` is called, we see the error.

### Open Issues
tbc

## How Has This Been Tested?
Tested accessing profile page without phone number 2FA enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
